### PR TITLE
Fixed typo (Neusoritierung --> Neusortierung)

### DIFF
--- a/src/main/resources/lang/de.json
+++ b/src/main/resources/lang/de.json
@@ -31,7 +31,7 @@
       "refresh": {
         "title": "<green>aktualisieren",
         "description": [
-          "<aqua>Neusoritierung der Gegenstände"
+          "<aqua>Neusortierung der Gegenstände"
         ]
       },
       "multiplier": {


### PR DESCRIPTION
There was a typo in the German language file:
Neusor**i**tierung is wrong, it has to be Neusortierung (without an _i_ in front of the t).