### PR TITLE
enable folia support.

### DIFF
--- a/fastcraft-bukkit/src/main/resources/plugin.yml
+++ b/fastcraft-bukkit/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ author: "${plugin_author}"
 version: "${plugin_version}"
 website: "${plugin_website}"
 api-version: "1.13"
-
+folia-supported: true
 description: "${plugin_description}"
 
 main: "net.benwoodworth.fastcraft.bukkit.BukkitFastCraft"


### PR DESCRIPTION
adding this to the plugin.yml enables folia support.

i have done some testing and the plugin works on folia just fine.
![image](https://github.com/BenWoodworth/FastCraft/assets/17603899/dddd085f-b6bc-4d20-940f-decb9ffb4f9c)

you can also just do it manually.